### PR TITLE
201402335_김진욱

### DIFF
--- a/src/main/java/com/study/week1/oop/pattern/strategy/AxeWeapon.java
+++ b/src/main/java/com/study/week1/oop/pattern/strategy/AxeWeapon.java
@@ -11,6 +11,6 @@ public class AxeWeapon implements WeaponStrategy {
 
 	@Override
 	public int damage() {
-		return (int)(damage + weight);
+		return (int)(damage * weight);
 	}
 }

--- a/src/main/java/com/study/week1/oop/pattern/strategy/BowWeapon.java
+++ b/src/main/java/com/study/week1/oop/pattern/strategy/BowWeapon.java
@@ -11,6 +11,6 @@ public class BowWeapon implements WeaponStrategy {
 
 	@Override
 	public int damage() {
-		return damage;
+		return damage+level;
 	}
 }

--- a/src/main/java/com/study/week1/oop/pattern/strategy/Chair.java
+++ b/src/main/java/com/study/week1/oop/pattern/strategy/Chair.java
@@ -3,7 +3,7 @@ package com.study.week1.oop.pattern.strategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class Chair {
+public class Chair implements WeaponStrategy{
 	Logger log = LoggerFactory.getLogger(this.getClass());
 	private Material material;
 	
@@ -25,5 +25,13 @@ public class Chair {
 		STONE,
 		IRON,
 		CRISTAL
+	}
+	
+	@Override
+	public int damage(){
+		if(this.material == Material.CRISTAL)
+			return 100;
+		else
+			return 2;
 	}
 }

--- a/src/test/java/com/study/week1/oop/access/AccessParentTest.java
+++ b/src/test/java/com/study/week1/oop/access/AccessParentTest.java
@@ -28,12 +28,12 @@ public class AccessParentTest {
 	 */
 	@Test
 	public void another() {
-		assertThat("Test코드를 수정해서 아래 코드를 해결할 것", another.getAccessParentNameByDefault(), is("AccessParent_Default"));
+		assertThat("Test코드를 수정해서 아래 코드를 해결할 것", another.getAccessParentNameByDefault(), is("Another : AccessParent_Default"));
 	}
 	
 	@Test
 	public void testAccessNameByProtected() {
-		assertThat("Test코드를 수정해서 아래 코드를 해결할 것", accessChildren.getNameByProtected(), is("AccessParent_Protected"));
+		assertThat("Test코드를 수정해서 아래 코드를 해결할 것", accessChildren.getNameByProtected(), is("Child : AccessParent_Protected"));
 	}
 
 	@Test
@@ -45,8 +45,9 @@ public class AccessParentTest {
 //		accessChildrenCasted.onlyChildren();	compile error
 		
 		// TODO Test코드를 수정해서 아래 fail을 해결
+		System.out.println(accessParentCasted.getNameByProtected());
 		assertThat("parent 로 캐스팅 됐지만, 객체는 여전히 children의 속성을 갖고 있다.", 
-				accessParentCasted.getNameByProtected(), is("AccessParent_Protected")); // 나 부모로 캐스팅 된거 아닌가??
+				accessParentCasted.getNameByProtected(), is("Child : AccessParent_Protected")); // 나 부모로 캐스팅 된거 아닌가??
 	}
 	
 	@Test
@@ -59,10 +60,10 @@ public class AccessParentTest {
 		float f2 = i;
 
 		// TODO Test코드를 수정해서 아래 fail을 해결
-		assertThat("데이터가 유실됐다!! primary type은 캐스팅때 조심해야 함.", f2, is(123.4f));		
+		assertThat("데이터가 유실됐다!! primary type은 캐스팅때 조심해야 함.", f2, is(123.0f));		
 	}
 	
-	@Test
+	@Test(expected = ClassCastException.class)
 	public void testException() throws Exception {
 		/* Compile error  
 		 * 

--- a/src/test/java/com/study/week1/oop/pattern/strategy/PlayerTest.java
+++ b/src/test/java/com/study/week1/oop/pattern/strategy/PlayerTest.java
@@ -70,7 +70,7 @@ public class PlayerTest {
 		 * chair 에 WeaponStrategy 를 구현하면 compile error 가 사라질 것이다. 
 		 */
 //		TODO 아래쪽 라인 player.setWeapon(chair); 이 컴파일 오류가 나지 않으며, assertThat 테스트 구문이 통과하도록 Chair.java 파일을 수정하라.
-//		player.setWeapon(chair);
+		player.setWeapon(chair);
 		
 		assertThat("기본 재료의 의자는 2의 데미지만 입힙니다.", player.attack(), is(2));
 		chair.setMaterial(Chair.Material.CRISTAL);


### PR DESCRIPTION
- AccessParentTest.java 수정
 1) another(), testAccessNameByProtected(), 상속과_형변환() : 객체 안의 내용을 보며 추가되는 문자열 수정
 2)랩퍼러_형변환() : float형을 int형으로 변경할 때 데이터 손실을 부분을 수정
 3) testException() : @test annotation expected로  fail 상황 수정

- PlayerTest.java, BowWeapon.java, AxeWeapon.java, Chair.java 수정
 1)setWeapon의 객체를 만들 때의 인자 값과 assertThat 값을 비교
 2)73번째 줄 주석을 지웠을 때 오류를 해결하기 위해 Chair.java 파일에 필요한 속성들을 구현함